### PR TITLE
Fix monthly event count display

### DIFF
--- a/src/components/calendar/__tests__/calendar-view.test.tsx
+++ b/src/components/calendar/__tests__/calendar-view.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import { CalendarView } from '../calendar-view'
+
+// Mock FullCalendar and related plugins to avoid heavy DOM dependencies
+jest.mock('@fullcalendar/react', () => {
+  return function MockFullCalendar() {
+    return <div data-testid="fullcalendar" />
+  }
+})
+jest.mock('@fullcalendar/daygrid', () => ({}))
+jest.mock('@fullcalendar/timegrid', () => ({}))
+jest.mock('@fullcalendar/interaction', () => ({}))
+
+// Mock useEvents to provide controlled event data
+jest.mock('../../../hooks/use-events', () => {
+  const events = [
+    {
+      id: '1',
+      title: 'May Event',
+      startTime: '2024-05-10T00:00:00Z',
+      endTime: '2024-05-10T01:00:00Z',
+      description: '',
+      city: '',
+      categories: [],
+      isSaved: false,
+    },
+    {
+      id: '2',
+      title: 'June Event',
+      startTime: '2024-06-05T00:00:00Z',
+      endTime: '2024-06-05T01:00:00Z',
+      description: '',
+      city: '',
+      categories: [],
+      isSaved: false,
+    },
+  ]
+  return {
+    useEvents: () => ({ data: events, isLoading: false })
+  }
+})
+
+describe('CalendarView', () => {
+  it('shows count of events only for the selected month', () => {
+    render(<CalendarView selectedDate={new Date('2024-05-01')} onDateSelect={() => {}} />)
+    expect(screen.getByText('1 events found')).toBeInTheDocument()
+  })
+})

--- a/src/components/calendar/calendar-view.tsx
+++ b/src/components/calendar/calendar-view.tsx
@@ -89,6 +89,16 @@ function CalendarContent({ selectedDate, onDateSelect }: CalendarViewProps) {
     }
   }))
 
+  // Count events occurring in the currently selected month
+  const eventsThisMonth = events.filter(event => {
+    if (!event.startTime) return false
+    const eventDate = new Date(event.startTime)
+    return (
+      eventDate.getMonth() === selectedDate.getMonth() &&
+      eventDate.getFullYear() === selectedDate.getFullYear()
+    )
+  })
+
   return (
     <Card className="p-6">
       {/* Custom Header */}
@@ -111,7 +121,7 @@ function CalendarContent({ selectedDate, onDateSelect }: CalendarViewProps) {
         </h2>
 
         <div className="text-sm text-muted-foreground">
-          {events.length} events found
+          {eventsThisMonth.length} events found
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- show number of events for the currently selected month instead of total events
- add unit test ensuring calendar header counts only events within the month

## Testing
- `npm test` *(fails: Cannot find module '../../../date-macau', unexpected token in cheerio, and missing marketing hero component)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d43f610c832d97bfd94a2e47f04b