### PR TITLE
Avoid adding default photo when event image exists

### DIFF
--- a/src/lib/image-fallbacks.test.ts
+++ b/src/lib/image-fallbacks.test.ts
@@ -1,0 +1,27 @@
+import { createEventImageGallery } from './image-fallbacks'
+
+describe('createEventImageGallery', () => {
+  it('returns only the event image when imageUrl is provided', () => {
+    const images = createEventImageGallery(
+      'https://example.com/event.jpg',
+      'Sample Event',
+      ['music'],
+      'Sample Venue'
+    )
+
+    expect(images).toHaveLength(1)
+    expect(images[0].id).toBe('event-image')
+  })
+
+  it('returns a default image when no event image is available', () => {
+    const images = createEventImageGallery(
+      undefined,
+      'Sample Event',
+      ['music'],
+      'Sample Venue'
+    )
+
+    expect(images).toHaveLength(1)
+    expect(images[0].id).toBe('concert')
+  })
+})

--- a/src/lib/image-fallbacks.ts
+++ b/src/lib/image-fallbacks.ts
@@ -199,19 +199,9 @@ export function createEventImageGallery(
     })
   }
   
-  // Always add a category-specific fallback
-  const fallbackImage = getCategoryDefaultImage(categories, venue, title)
-  
-  // Only add fallback if we don't have an event image, or add it as a second image
+  // Add a category-specific fallback only when no event image is available
   if (images.length === 0) {
-    images.push(fallbackImage)
-  } else if (images.length === 1) {
-    // Add fallback as second image for variety
-    images.push({
-      ...fallbackImage,
-      id: 'fallback',
-      caption: 'Category preview'
-    })
+    images.push(getCategoryDefaultImage(categories, venue, title))
   }
   
   return images


### PR DESCRIPTION
## Summary
- Stop appending a fallback image when an event already provides its own photo
- Add unit tests for event image fallback logic

## Testing
- `npm test` *(fails: Jest cannot parse some scraper test files and missing modules)*
- `npm test src/lib/image-fallbacks.test.ts`
- `npm run lint` *(warnings about Next.js ESLint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e63213dc832d912ef9bfb03d0f3a