### PR TITLE
feat: support multiple event images

### DIFF
--- a/database/complete-setup-with-macau-daily.sql
+++ b/database/complete-setup-with-macau-daily.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS events (
   categories TEXT[] DEFAULT ARRAY['local_events'],
   tags TEXT[],
   image_url TEXT,
+  image_urls TEXT[],
   organizer_name TEXT,
   external_url TEXT,
   last_seen_at TIMESTAMPTZ DEFAULT now(),

--- a/database/setup.sql
+++ b/database/setup.sql
@@ -35,6 +35,7 @@ CREATE TABLE events (
   categories TEXT[] DEFAULT ARRAY['local_events'],
   tags TEXT[],
   image_url TEXT,
+  image_urls TEXT[],
   organizer_name TEXT,
   external_url TEXT,
   last_seen_at TIMESTAMPTZ DEFAULT now(),

--- a/database/supabase-complete-setup.sql
+++ b/database/supabase-complete-setup.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS events (
   categories TEXT[] DEFAULT ARRAY['local_events'],
   tags TEXT[],
   image_url TEXT,
+  image_urls TEXT[],
   organizer_name TEXT,
   external_url TEXT,
   last_seen_at TIMESTAMPTZ DEFAULT now(),
@@ -296,6 +297,7 @@ RETURNS TABLE (
   country TEXT,
   categories TEXT[],
   image_url TEXT,
+  image_urls TEXT[],
   external_url TEXT
 ) AS $$
 BEGIN
@@ -312,6 +314,7 @@ BEGIN
     e.country,
     e.categories,
     e.image_url,
+    e.image_urls,
     e.external_url
   FROM events e
   WHERE e.city ILIKE '%' || city_name || '%'
@@ -334,6 +337,7 @@ RETURNS TABLE (
   country TEXT,
   categories TEXT[],
   image_url TEXT,
+  image_urls TEXT[],
   external_url TEXT,
   note TEXT,
   saved_at TIMESTAMPTZ
@@ -352,6 +356,7 @@ BEGIN
     e.country,
     e.categories,
     e.image_url,
+    e.image_urls,
     e.external_url,
     se.note,
     se.created_at as saved_at

--- a/src/components/ui/event-modal.tsx
+++ b/src/components/ui/event-modal.tsx
@@ -156,9 +156,16 @@ export const EventModalContent = ({
   if (!eventData) return null
 
   // Create intelligent image gallery with category-specific fallbacks
-  const validatedImageUrl = validateImageUrl(eventData.imageUrl)
+  const validatedImageUrls = (
+    eventData.imageUrls && eventData.imageUrls.length > 0
+      ? eventData.imageUrls
+      : [eventData.imageUrl]
+  )
+    .map((url) => validateImageUrl(url))
+    .filter((url): url is string => Boolean(url))
+
   const images = createEventImageGallery(
-    validatedImageUrl,
+    validatedImageUrls,
     eventData.title,
     eventData.categories,
     eventData.venueName

--- a/src/hooks/use-events.ts
+++ b/src/hooks/use-events.ts
@@ -82,6 +82,7 @@ export function useEvents(options: UseEventsOptions = {}) {
         categories: event.categories || [],
         tags: event.tags || [],
         imageUrl: event.image_url,
+        imageUrls: event.image_urls || [],
         organizerName: event.organizer_name,
         externalUrl: event.external_url,
         lastSeenAt: event.last_seen_at,

--- a/src/lib/event-ingestion.ts
+++ b/src/lib/event-ingestion.ts
@@ -189,6 +189,7 @@ async function processBatch(supabaseAdmin: any, events: Partial<Event>[]): Promi
             categories: event.categories,
             tags: event.tags,
             image_url: event.imageUrl,
+            image_urls: event.imageUrls,
             organizer_name: event.organizerName,
             external_url: event.externalUrl,
             last_seen_at: new Date().toISOString()
@@ -221,6 +222,7 @@ async function processBatch(supabaseAdmin: any, events: Partial<Event>[]): Promi
             categories: event.categories || ['local_events'],
             tags: event.tags || [],
             image_url: event.imageUrl,
+            image_urls: event.imageUrls,
             organizer_name: event.organizerName,
             external_url: event.externalUrl,
             last_seen_at: event.lastSeenAt || new Date().toISOString()

--- a/src/lib/image-fallbacks.test.ts
+++ b/src/lib/image-fallbacks.test.ts
@@ -3,7 +3,7 @@ import { createEventImageGallery } from './image-fallbacks'
 describe('createEventImageGallery', () => {
   it('returns only the event image when imageUrl is provided', () => {
     const images = createEventImageGallery(
-      'https://example.com/event.jpg',
+      ['https://example.com/event.jpg'],
       'Sample Event',
       ['music'],
       'Sample Venue'
@@ -15,7 +15,7 @@ describe('createEventImageGallery', () => {
 
   it('returns a default image when no event image is available', () => {
     const images = createEventImageGallery(
-      undefined,
+      [],
       'Sample Event',
       ['music'],
       'Sample Venue'

--- a/src/lib/image-fallbacks.ts
+++ b/src/lib/image-fallbacks.ts
@@ -182,28 +182,30 @@ export function getCategoryDefaultImage(categories: string[] = [], venue?: strin
  * Create image gallery from event data with intelligent fallbacks
  */
 export function createEventImageGallery(
-  imageUrl?: string | null,
+  imageUrls: string[] = [],
   title?: string,
   categories?: string[],
   venue?: string
 ): EventImageData[] {
   const images: EventImageData[] = []
-  
-  // Add actual event image if available
-  if (imageUrl && imageUrl.trim()) {
-    images.push({
-      id: 'event-image',
-      url: imageUrl,
-      alt: title || 'Event image',
-      caption: 'Event photo'
-    })
-  }
-  
+
+  // Add actual event images if available (limit to 3)
+  imageUrls.slice(0, 3).forEach((url, index) => {
+    if (url && url.trim()) {
+      images.push({
+        id: index === 0 ? 'event-image' : `event-image-${index}`,
+        url,
+        alt: title || 'Event image',
+        caption: 'Event photo'
+      })
+    }
+  })
+
   // Add a category-specific fallback only when no event image is available
   if (images.length === 0) {
     images.push(getCategoryDefaultImage(categories, venue, title))
   }
-  
+
   return images
 }
 

--- a/src/lib/scrapers/macau-coordinator.ts
+++ b/src/lib/scrapers/macau-coordinator.ts
@@ -170,7 +170,8 @@ export class MacauCoordinator {
         lng: this.getApproximateLongitude(rawEvent.source),
         categories: categories,
         tags: tags,
-        imageUrl: rawEvent.image_url,
+        imageUrl: rawEvent.image_url || rawEvent.image_urls?.[0],
+        imageUrls: rawEvent.image_urls,
         organizerName: this.getOrganizerName(rawEvent.source),
         externalUrl: rawEvent.url,
         lastSeenAt: new Date().toISOString()

--- a/src/lib/scrapers/macau/sands.ts
+++ b/src/lib/scrapers/macau/sands.ts
@@ -365,6 +365,9 @@ export class SandsScraper extends BaseScraper implements MacauScraper {
       // Determine categories
       const categories = this.categorizeEvent(title, description, this.venue)
 
+      // Extract up to three images
+      const imageUrls = this.extractImageUrls($, $element, this.baseUrl)
+
       const event: RawEvent = {
         source: this.venue,
         source_id: createSourceId(title, parsedDate.start, venue, this.getDomainFromUrl(this.baseUrl)),
@@ -376,7 +379,8 @@ export class SandsScraper extends BaseScraper implements MacauScraper {
         city: 'Macau',
         url: eventUrl,
         ticket_url: ticketUrl || undefined,
-        image_url: this.extractImageUrl($, $element, this.baseUrl),
+        image_url: imageUrls[0],
+        image_urls: imageUrls,
         categories
       }
 
@@ -467,13 +471,18 @@ export class SandsScraper extends BaseScraper implements MacauScraper {
         ticketUrl = this.safeAttr($cotaiLink, 'href') || ticketUrl
       }
 
+      // Extract up to three images from detail page
+      const detailImages = this.extractDetailPageImages($, this.baseUrl)
+      const combinedImages = detailImages.length > 0 ? detailImages : (event.image_urls || [])
+
       return {
         ...event,
         description: enhancedDescription,
         start: enhancedDate,
         venue: enhancedVenue,
         ticket_url: ticketUrl,
-        image_url: this.extractDetailPageImage($, this.baseUrl) || event.image_url
+        image_url: combinedImages[0] || event.image_url,
+        image_urls: combinedImages.length > 0 ? combinedImages : event.image_urls
       }
 
     } catch (error) {

--- a/src/lib/scrapers/types.ts
+++ b/src/lib/scrapers/types.ts
@@ -13,7 +13,8 @@ export interface RawEvent {
   city: string              // Allow any city for AI scraper
   url: string               // detail page URL
   ticket_url?: string       // if available
-  image_url?: string        // event image if available
+  image_url?: string        // primary event image if available
+  image_urls?: string[]     // additional event images (max 3)
   price_min?: number
   categories?: string[]
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -52,6 +52,7 @@ export interface Database {
           categories: string[]
           tags: string[]
           image_url: string | null
+          image_urls: string[] | null
           organizer_name: string | null
           external_url: string | null
           last_seen_at: string
@@ -74,6 +75,7 @@ export interface Database {
           categories?: string[]
           tags?: string[]
           image_url?: string | null
+          image_urls?: string[] | null
           organizer_name?: string | null
           external_url?: string | null
           last_seen_at?: string
@@ -96,6 +98,7 @@ export interface Database {
           categories?: string[]
           tags?: string[]
           image_url?: string | null
+          image_urls?: string[] | null
           organizer_name?: string | null
           external_url?: string | null
           last_seen_at?: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,6 +26,7 @@ export interface Event {
   categories: string[]
   tags: string[]
   imageUrl?: string
+  imageUrls?: string[]
   organizerName?: string
   externalUrl?: string
   lastSeenAt: string


### PR DESCRIPTION
## Summary
- allow base scraper to collect up to three image URLs and surface them on detail pages
- extend event schema and ingestion to store multiple images
- update UI gallery to display up to three event photos

## Testing
- `npm test` *(fails: Cannot find module '../../../date-macau' and Jest ESM parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ee7ec738832d9b1a43e99fa96de2